### PR TITLE
Refactor API routing and add statistics endpoint

### DIFF
--- a/app/api/v1/routes/routes.py
+++ b/app/api/v1/routes/routes.py
@@ -1,8 +1,10 @@
 from fastapi import APIRouter
 
 from app.api.v1.routes.colorize import router as colorize_router
+from app.api.v1.routes.stats import router as stats_router
 
 router = APIRouter()
 
 # Include routers
 router.include_router(colorize_router, prefix="/colorize", tags=["Colorize"])
+router.include_router(stats_router, prefix="/stats", tags=["Stats"])

--- a/app/api/v1/routes/stats.py
+++ b/app/api/v1/routes/stats.py
@@ -1,0 +1,55 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from app.db.supabase_db import get_supabase_client, safe_supabase_operation
+from datetime import datetime
+
+router = APIRouter()
+
+class StatsResponse(BaseModel):
+    total_users: int
+    total_memories: int
+    last_updated: str
+
+@router.get("/", response_model=StatsResponse)
+async def get_stats():
+    """
+    Get the latest statistics from colorize_events_totals table.
+    Returns total users and total memories processed.
+    """
+    try:
+        supabase = get_supabase_client()
+        
+        # Fetch totals from the new table
+        def fetch_stats():
+            response = supabase.table("colorize_events_totals")\
+                .select("total_unique_users, total_memories")\
+                .limit(1)\
+                .execute()
+            return response
+        
+        result = await safe_supabase_operation(
+            fetch_stats,
+            "Failed to fetch stats from database"
+        )
+        
+        if not result.data:
+            # Return default values if no data exists
+            return StatsResponse(
+                total_users=0,
+                total_memories=0,
+                last_updated=datetime.now().isoformat()
+            )
+        
+        record = result.data[0]
+        
+        return StatsResponse(
+            total_users=record.get("total_unique_users", 0),
+            total_memories=record.get("total_memories", 0),
+            last_updated=datetime.now().isoformat()
+        )
+        
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to retrieve stats: {str(e)}"
+        )

--- a/app/main.py
+++ b/app/main.py
@@ -93,8 +93,8 @@ async def generic_exception_handler(request: Request, exc: Exception):
     )
 
 # ----- Register routers -----
-# v1 grouped under /v1/routes
-app.include_router(api_router, prefix="/v1")
+# v1 grouped under /api/v1/routes
+app.include_router(api_router, prefix="/api/v1")
 
 # Root endpoint
 @app.get("/")


### PR DESCRIPTION
- Updated API router prefix from /v1 to /api/v1 for clarity.
- Introduced a new stats endpoint to retrieve user and memory statistics from the colorize_events_totals table.
- Added a response model for the stats endpoint to structure the returned data.